### PR TITLE
Added legacy imports for older app code.

### DIFF
--- a/jarvis/analysis/interface/zur.py
+++ b/jarvis/analysis/interface/zur.py
@@ -442,11 +442,18 @@ def get_hetero_type(A={}, B={}):
     return int_type, stack
 
 
-# Legacy functions, present so app imports won't fail.
 def mismatch_strts():
+    """
+    Return mismatch and other information as info dict.
+    Deprecated, preserved here so legacy imports work.
+    """
     pass
+
+
 def get_heter():
+    """Generate heterostructure. Deprecated also."""
     pass
+
 
 """
 if __name__ == "__main__":

--- a/jarvis/analysis/interface/zur.py
+++ b/jarvis/analysis/interface/zur.py
@@ -442,6 +442,12 @@ def get_hetero_type(A={}, B={}):
     return int_type, stack
 
 
+# Legacy functions, present so app imports won't fail.
+def mismatch_strts():
+    pass
+def get_heter():
+    pass
+
 """
 if __name__ == "__main__":
     s1 = Poscar.from_file(


### PR DESCRIPTION
Added stub functions to the zur.py file.  These functions are imported but not used by the still-deployed version of the heterostructures app. Re-adding them here localizes the changes to a single repo. The long-term solution will remove both these stubs and the imports in the other repo, but this is a good near-term solution.