### PR TITLE
Fixed a typo'd legacy function name.

### DIFF
--- a/jarvis/analysis/interface/zur.py
+++ b/jarvis/analysis/interface/zur.py
@@ -450,7 +450,7 @@ def mismatch_strts():
     pass
 
 
-def get_heter():
+def get_hetero():
     """Generate heterostructure. Deprecated also."""
     pass
 


### PR DESCRIPTION
So it turns out there was a typo in the second legacy function, this PR fixes it.