### PR TITLE
Cleanup graph

### DIFF
--- a/jarvis/core/graphs.py
+++ b/jarvis/core/graphs.py
@@ -77,7 +77,10 @@ class Graph(object):
         dim = get_supercell_dims(atoms=atoms, enforce_c_size=enforce_c_size)
         atoms = atoms.make_supercell(dim)
 
-        adj = np.array(atoms.raw_distance_matrix)
+        adj = np.array(atoms.raw_distance_matrix.copy())
+
+        # zero out edges with bond length greater than threshold
+        adj[adj >= max_cut] = 0
 
         if zero_diag:
             np.fill_diagonal(adj, 0.0)
@@ -137,13 +140,19 @@ class Graph(object):
                 (node_attributes, nbr.atomwise_angle_dist()), axis=1
             )
             node_attributes = np.array(node_attributes, dtype="float")
+
+        # construct edge list
         uv = []
         edge_features = []
         for ii, i in enumerate(atoms.elements):
             for jj, j in enumerate(atoms.elements):
-                uv.append((ii, jj))
-                edge_features.append(adj[ii, jj])
+                bondlength = adj[ii, jj]
+                if bondlength > 0:
+                    uv.append((ii, jj))
+                    edge_features.append(bondlength)
+
         edge_attributes = edge_features
+
         if make_colormap:
             sps = atoms.uniq_species
             color_dict = random_colors(number_of_colors=len(sps))

--- a/jarvis/core/graphs.py
+++ b/jarvis/core/graphs.py
@@ -221,9 +221,10 @@ class Graph(object):
     @property
     def adjacency_matrix(self):
         """Provide adjacency_matrix of graph."""
-        return np.array(self.edge_attributes).reshape(
-            self.num_nodes, self.num_nodes
-        )
+        A = np.zeros((self.num_nodes, self.num_nodes))
+        for edge, a in zip(self.edges, self.edge_attributes):
+            A[edge] = a
+        return A
 
 
 """

--- a/jarvis/core/graphs.py
+++ b/jarvis/core/graphs.py
@@ -43,8 +43,6 @@ class Graph(object):
     @staticmethod
     def from_atoms(
         atoms=None,
-        lengthscale=0.5,
-        variance=1.0,
         get_prim=False,
         zero_diag=False,
         node_atomwise_angle_dist=False,
@@ -78,8 +76,9 @@ class Graph(object):
             atoms = atoms.get_primitive_atoms
         dim = get_supercell_dims(atoms=atoms, enforce_c_size=enforce_c_size)
         atoms = atoms.make_supercell(dim)
-        raw_data = np.array(atoms.raw_distance_matrix)
-        adj = variance * np.exp(-raw_data / lengthscale)
+
+        adj = np.array(atoms.raw_distance_matrix)
+
         if zero_diag:
             np.fill_diagonal(adj, 0.0)
         nodes = np.arange(atoms.num_atoms)

--- a/jarvis/tests/testfiles/core/test_graph.py
+++ b/jarvis/tests/testfiles/core/test_graph.py
@@ -35,7 +35,7 @@ def test_graph():
     g = Graph.from_atoms(
         atoms=atoms, features=["Z", "atom_mass", "max_oxid_s"]
     )
-    g = Graph.from_atoms(atoms=atoms, features="cfid")
+    g = Graph.from_atoms(atoms=atoms, features="cfid", max_cut=10000)
     print(g)
     d = g.to_dict()
     g = Graph.from_dict(d)
@@ -43,5 +43,5 @@ def test_graph():
     num_edges = g.num_edges
     print(num_nodes, num_edges)
     assert num_nodes == 48
-    assert num_edges == 2304
+    assert num_edges == 2256
     assert (g.adjacency_matrix.shape) == (48,48)


### PR DESCRIPTION
This PR sets the adjacency matrix weights to bond lengths in jarvis.core.graph.Graph, and also applies the `max_cut` argument to limit edges in the graph to below this threshould