### PR TITLE
Cache graph dataset

### DIFF
--- a/.github/workflows/action_build.yml
+++ b/.github/workflows/action_build.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
-        
+
     - name: Install requirements
       run: |
         python setup.py develop
@@ -27,12 +27,12 @@ jobs:
 
         echo 'CONDA LIST'
         conda list
-        
+
         echo 'PIP FREEZE'
         pip freeze
 
         #echo 'PYTEST-COV'
-        #pytest --cov-config=.coveragerc --cov=jarvis -n 2 
+        #pytest --cov-config=.coveragerc --cov=jarvis -n 2
 
 
         coverage run -m pytest
@@ -44,7 +44,7 @@ jobs:
         # ./configure
         # make pw
 
-        
+
 
 #jobs:
 #   miniconda:
@@ -77,7 +77,7 @@ jobs:
 #         run: |
 #             python setup.py develop
 #             #pip uninstall qiskit
-#             # pip install qiskit ase  numpy==1.18.5 scipy==1.4.1 matplotlib>=3.0.0 phonopy==2.8.1 coverage lightgbm==2.1.0  flask joblib networkx scikit-learn pandas pennylane dgl tqdm  codecov torch keras tensorflow==2.3.0  pytest pytest-cov bokeh pytest-xdist
+#             # pip install qiskit ase  numpy==1.18.5 scipy==1.4.1 matplotlib>=3.0.0 phonopy==2.8.1 coverage lightgbm==2.1.0  flask joblib networkx scikit-learn pandas pennylane==0.14.1 dgl tqdm  codecov torch keras tensorflow==2.3.0  pytest pytest-cov bokeh pytest-xdist
 #             # pip install git+https://github.com/aspuru-guzik-group/tequila.git
 #             # pip install -r requirements-for-ci-only.txt
 #             # pip install -r dev-requirements.txt
@@ -97,4 +97,3 @@ jobs:
 #             # cd q-e
 #             # ./configure
 #             # make pw
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,24 +1,24 @@
 wheel
 qiskit >= 0.24.0
-ase>=3.21.1   
-numpy>=1.18.5 
-scipy>=1.4.1 
-matplotlib>=3.0.0 
-phonopy>=2.8.1 
-coverage>=5.5 
-lightgbm>=2.1.0  
+ase>=3.21.1
+numpy>=1.18.5
+scipy>=1.4.1
+matplotlib>=3.0.0
+phonopy>=2.8.1
+coverage>=5.5
+lightgbm>=2.1.0
 flask >=1.1.2
 joblib >=1.0.1
-networkx >=2.5 
+networkx >=2.5
 scikit-learn >=0.24.1
 pandas >=1.2.3
 dgl>=0.6.0.post1
-tqdm>=4.59.0 
-pennylane>=0.14.1   
+tqdm>=4.59.0
+pennylane==0.14.1
 codecov >=2.1.11
 torch >=1.8.0
 keras >=2.4.3
-tensorflow>=2.4.0  
+tensorflow>=2.4.0
 cif2cell
 pytest >=6.2.2
 pytest-cov >=2.11.1

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,2 +1,2 @@
 """Version number."""
-__version__ = "2021.4.19"
+__version__ = "2021.4.21"

--- a/jarvis/core/graphs.py
+++ b/jarvis/core/graphs.py
@@ -3,11 +3,13 @@ from jarvis.core.atoms import get_supercell_dims
 from jarvis.core.specie import Specie
 from jarvis.core.utils import random_colors
 import numpy as np
+import pandas as pd
 from collections import OrderedDict
 from jarvis.analysis.structure.neighbors import NeighborsAnalysis
-from jarvis.core.specie import get_node_attributes
+from jarvis.core.specie import chem_data, get_node_attributes
 from jarvis.core.atoms import Atoms
 from collections import defaultdict
+from typing import List, Tuple, Sequence, Optional
 
 try:
     import torch
@@ -131,9 +133,7 @@ def build_undirected_edgedata(
             # fractional coordinate for periodic image of dst
             dst_coord = atoms.frac_coords[dst_id] + dst_image
             # cartesian displacement vector pointing from src -> dst
-            d = atoms.lattice.cart_coords(
-                dst_coord - atoms.frac_coords[src_id]
-            )
+            d = atoms.lattice.cart_coords(dst_coord - atoms.frac_coords[src_id])
             # if np.linalg.norm(d)!=0:
             # print ('jv',dst_image,d)
             # add edges for both directions
@@ -190,7 +190,8 @@ class Graph(object):
         max_neighbors=12,
         atom_features="cgcnn",
         max_attempts=3,
-        id="JVASP-6172",
+        id: Optional[str] = None,
+        compute_line_graph: bool = True,
     ):
         """Obtain a DGLGraph for Atoms object."""
         if neighbor_strategy == "k-nearest":
@@ -208,24 +209,27 @@ class Graph(object):
         u, v, r = build_undirected_edgedata(atoms, edges)
 
         # build up atom attribute tensor
-        species = atoms.elements
         sps_features = []
-        for ii, s in enumerate(species):
+        for ii, s in enumerate(atoms.elements):
             feat = list(get_node_attributes(s, atom_features=atom_features))
             # if include_prdf_angles:
             #    feat=feat+list(prdf[ii])+list(adf[ii])
             sps_features.append(feat)
         sps_features = np.array(sps_features)
-        node_features = torch.tensor(sps_features).type(
-            torch.get_default_dtype()
-        )
+        node_features = torch.tensor(sps_features).type(torch.get_default_dtype())
         g = dgl.graph((u, v))
         g.ndata["atom_features"] = node_features
         g.edata["r"] = r
-        lg = g.line_graph(shared=True)
-        lg.apply_edges(compute_bond_cosines)
 
-        return g, lg
+        if compute_line_graph:
+            # construct atomistic line graph
+            # (nodes are bonds, edges are bond pairs)
+            # and add bond angle cosines as edge features
+            lg = g.line_graph(shared=True)
+            lg.apply_edges(compute_bond_cosines)
+            return g, lg
+        else:
+            return g
 
     @staticmethod
     def from_atoms(
@@ -441,27 +445,43 @@ class Standardize(torch.nn.Module):
         return g
 
 
-def prepare_dgl_batch(batch, device=None, non_blocking=False):
-    """Send batched dgl graph to device."""
-    g, lg, t = batch
-    batch = ((g.to(device), lg.to(device)), t.to(device))
-    # g, t = batch
-    # batch = (g.to(device), t.to(device))
+def prepare_dgl_batch(
+    batch: Tuple[dgl.DGLGraph, torch.Tensor], device=None, non_blocking=False
+):
+    """Send batched dgl crystal graph to device."""
+    g, t = batch
+    batch = (
+        g.to(device, non_blocking=non_blocking),
+        t.to(device, non_blocking=non_blocking),
+    )
 
     return batch
 
 
-def prepare_line_graph_batch(batch, device=None, non_blocking=False):
-    """Send batched dgl graph to device."""
+def prepare_line_graph_batch(
+    batch: Tuple[Tuple[dgl.DGLGraph, dgl.DGLGraph], torch.Tensor],
+    device=None,
+    non_blocking=False,
+):
+    """Send line graph batch to device.
+
+    Note: the batch is a nested tuple, with the graph and line graph together
+    """
     g, lg, t = batch
-    batch = ((g.to(device), lg.to(device)), t.to(device))
+    batch = (
+        (
+            g.to(device, non_blocking=non_blocking),
+            lg.to(device, non_blocking=non_blocking),
+        ),
+        t.to(device, non_blocking=non_blocking),
+    )
 
     return batch
 
 
-def prepare_batch(batch, device=None):
-    """Send tuple to device, including DGLGraphs."""
-    return tuple(x.to(device) for x in batch)
+# def prepare_batch(batch, device=None):
+#     """Send tuple to device, including DGLGraphs."""
+#     return tuple(x.to(device) for x in batch)
 
 
 def compute_bond_cosines(edges):
@@ -489,51 +509,76 @@ class StructureDataset(torch.utils.data.Dataset):
 
     def __init__(
         self,
-        structures,
-        targets,
-        ids=None,
-        cutoff=8.0,
-        maxrows=np.inf,
-        atom_features="cgcnn",
+        df: pd.DataFrame,
+        graphs: Sequence[dgl.DGLGraph],
+        target: str,
+        atom_features="atomic_number",
         transform=None,
-        enforce_undirected=False,
-        max_neighbors=12,
-        neighbor_strategy="k-nearest",
+        line_graph=False,
         classification=False,
     ):
-        """Initialize the class."""
-        self.graphs = []
-        self.labels = []
-        self.ids = []
-        self.line_graphs = []
+        """Pytorch Dataset for atomistic graphs.
 
-        for idx, (structure, target, id) in enumerate(
-            tqdm(zip(structures, targets, ids))
-        ):
+        `df`: pandas dataframe from e.g. jarvis.db.figshare.data
+        `graphs`: DGLGraph representations corresponding to rows in `df`
+        `target`: key for label column in `df`
+        """
+        self.df = df
+        self.graphs = graphs
+        self.target = target
+        self.line_graph = line_graph
 
-            if idx >= maxrows:
-                break
-            a = Atoms.from_dict(structure)
-            g, lg = Graph.atom_dgl_multigraph(
-                a,
-                atom_features=atom_features,
-                cutoff=cutoff,
-                max_neighbors=max_neighbors,
-                id=id,
-            )
+        self.labels = self.df[target]
+        self.ids = self.df["jid"]
+        self.labels = torch.tensor(self.df[target]).type(torch.get_default_dtype())
+        self.transform = transform
 
-            self.graphs.append(g)
-            self.line_graphs.append(lg)
-            self.labels.append(target)
-            self.ids.append(id)
+        features = self._get_attribute_lookup(atom_features)
 
-        self.labels = torch.tensor(self.labels).type(torch.get_default_dtype())
+        # load selected node representation
+        # assume graphs contain atomic number in g.ndata["atom_features"]
+        for g in graphs:
+            z = g.ndata.pop("atom_features")
+            g.ndata["atomic_number"] = z
+            z = z.type(torch.IntTensor).squeeze()
+            f = torch.tensor(features[z]).type(torch.FloatTensor)
+            if g.num_nodes() == 1:
+                f = f.unsqueeze(0)
+            g.ndata["atom_features"] = f
+
+        self.prepare_batch = prepare_dgl_batch
+        if line_graph:
+            self.prepare_batch = prepare_line_graph_batch
+
+            print("building line graphs")
+            self.line_graphs = []
+            for g in tqdm(graphs):
+                lg = g.line_graph(shared=True)
+                lg.apply_edges(compute_bond_cosines)
+                self.line_graphs.append(lg)
+
         if classification:
             self.labels = self.labels.view(-1).long()
             print("Classification dataset.", self.labels)
 
-        self.transform = transform
-        self.prepare_batch = prepare_line_graph_batch
+    @staticmethod
+    def _get_attribute_lookup(atom_features: str = "cgcnn"):
+        """Build a lookup array indexed by atomic number."""
+        max_z = max(v["Z"] for v in chem_data.values())
+
+        # get feature shape (referencing Carbon)
+        template = get_node_attributes("C", atom_features)
+
+        features = np.zeros((1 + max_z, len(template)))
+
+        for element, v in chem_data.items():
+            z = v["Z"]
+            x = get_node_attributes(element, atom_features)
+
+            if x is not None:
+                features[z, :] = x
+
+        return features
 
     def __len__(self):
         """Get length."""
@@ -546,35 +591,42 @@ class StructureDataset(torch.utils.data.Dataset):
 
         if self.transform:
             g = self.transform(g)
-        # return g,  label
-        return g, self.line_graphs[idx], label
 
-    def setup_standardizer(self):
+        if self.line_graph:
+            return g, self.line_graphs[idx], label
+
+        return g, label
+
+    def setup_standardizer(self, ids):
         """Atom-wise feature standardization transform."""
-        x = torch.cat([g.ndata["atom_features"] for g in self.graphs])
+        x = torch.cat(
+            [
+                g.ndata["atom_features"]
+                for idx, g in enumerate(self.graphs)
+                if idx in ids
+            ]
+        )
         self.atom_feature_mean = x.mean(0)
         self.atom_feature_std = x.std(0)
 
-        self.transform = Standardize(
-            self.atom_feature_mean, self.atom_feature_std
-        )
+        self.transform = Standardize(self.atom_feature_mean, self.atom_feature_std)
 
     @staticmethod
-    def collate(samples):
+    def collate(samples: List[Tuple[dgl.DGLGraph, torch.Tensor]]):
         """Dataloader helper to batch graphs cross `samples`."""
-        # device = "cpu"
-        # if torch.cuda.is_available():
-        #    device = torch.device("cuda")
-        # graphs,  labels = map(list, zip(*samples))
+        graphs, labels = map(list, zip(*samples))
+        batched_graph = dgl.batch(graphs)
+        return batched_graph, torch.tensor(labels)
+
+    @staticmethod
+    def collate_line_graph(
+        samples: List[Tuple[dgl.DGLGraph, dgl.DGLGraph, torch.Tensor]]
+    ):
+        """Dataloader helper to batch graphs cross `samples`."""
         graphs, line_graphs, labels = map(list, zip(*samples))
         batched_graph = dgl.batch(graphs)
         batched_line_graph = dgl.batch(line_graphs)
-        # return batched_graph.to(device),  torch.tensor(labels).to(device)
-        return (
-            batched_graph,
-            batched_line_graph,
-            torch.tensor(labels),
-        )  # .to(device)
+        return batched_graph, batched_line_graph, torch.tensor(labels)
 
 
 """

--- a/jarvis/core/graphs.py
+++ b/jarvis/core/graphs.py
@@ -133,7 +133,9 @@ def build_undirected_edgedata(
             # fractional coordinate for periodic image of dst
             dst_coord = atoms.frac_coords[dst_id] + dst_image
             # cartesian displacement vector pointing from src -> dst
-            d = atoms.lattice.cart_coords(dst_coord - atoms.frac_coords[src_id])
+            d = atoms.lattice.cart_coords(
+                dst_coord - atoms.frac_coords[src_id]
+            )
             # if np.linalg.norm(d)!=0:
             # print ('jv',dst_image,d)
             # add edges for both directions
@@ -216,7 +218,9 @@ class Graph(object):
             #    feat=feat+list(prdf[ii])+list(adf[ii])
             sps_features.append(feat)
         sps_features = np.array(sps_features)
-        node_features = torch.tensor(sps_features).type(torch.get_default_dtype())
+        node_features = torch.tensor(sps_features).type(
+            torch.get_default_dtype()
+        )
         g = dgl.graph((u, v))
         g.ndata["atom_features"] = node_features
         g.edata["r"] = r
@@ -530,7 +534,9 @@ class StructureDataset(torch.utils.data.Dataset):
 
         self.labels = self.df[target]
         self.ids = self.df["jid"]
-        self.labels = torch.tensor(self.df[target]).type(torch.get_default_dtype())
+        self.labels = torch.tensor(self.df[target]).type(
+            torch.get_default_dtype()
+        )
         self.transform = transform
 
         features = self._get_attribute_lookup(atom_features)
@@ -609,7 +615,9 @@ class StructureDataset(torch.utils.data.Dataset):
         self.atom_feature_mean = x.mean(0)
         self.atom_feature_std = x.std(0)
 
-        self.transform = Standardize(self.atom_feature_mean, self.atom_feature_std)
+        self.transform = Standardize(
+            self.atom_feature_mean, self.atom_feature_std
+        )
 
     @staticmethod
     def collate(samples: List[Tuple[dgl.DGLGraph, torch.Tensor]]):

--- a/jarvis/core/specie.py
+++ b/jarvis/core/specie.py
@@ -7,12 +7,16 @@ import functools
 from jarvis.core.utils import digitize_array
 from collections import defaultdict
 
-el_chem_json_file = str(os.path.join(os.path.dirname(__file__), "Elements.json"))
+el_chem_json_file = str(
+    os.path.join(os.path.dirname(__file__), "Elements.json")
+)
 el_chem_json = open(el_chem_json_file, "r")
 chem_data = json.load(el_chem_json)
 el_chem_json.close()
 
-el_chrg_json_file = str(os.path.join(os.path.dirname(__file__), "element_charge.json"))
+el_chrg_json_file = str(
+    os.path.join(os.path.dirname(__file__), "element_charge.json")
+)
 el_chrg_json = open(el_chrg_json_file, "r")
 chrg_data = json.load(el_chrg_json)
 el_chrg_json.close()
@@ -258,14 +262,18 @@ def get_node_attributes(species, atom_features="atomic_number"):
     feature_sets = ("atomic_number", "basic", "cfid", "cgcnn")
 
     if atom_features not in feature_sets:
-        raise NotImplementedError(f"atom features must be one of {feature_sets}")
+        raise NotImplementedError(
+            f"atom features must be one of {feature_sets}"
+        )
 
     if atom_features == "cfid":
         return Specie(species).get_descrp_arr
     elif atom_features == "atomic_number":
         return [Specie(species).element_property("Z")]
     elif atom_features == "basic":
-        return [Specie(species).element_property(prop) for prop in BASIC_FEATURES]
+        return [
+            Specie(species).element_property(prop) for prop in BASIC_FEATURES
+        ]
     elif atom_features == "cgcnn":
         # load from json, key by atomic number
         key = str(Specie(species).element_property("Z"))
@@ -373,7 +381,9 @@ def get_specie_data():
     return keys, chem_data, chrg_data
 
 
-def get_digitized_feats_hot_encoded(feature_names=keys, filename="feats_encoded.json"):
+def get_digitized_feats_hot_encoded(
+    feature_names=keys, filename="feats_encoded.json"
+):
     """Get OneHotEncoded features with digitized features."""
     from sklearn.preprocessing import OneHotEncoder
     import pandas as pd

--- a/jarvis/core/specie.py
+++ b/jarvis/core/specie.py
@@ -7,16 +7,12 @@ import functools
 from jarvis.core.utils import digitize_array
 from collections import defaultdict
 
-el_chem_json_file = str(
-    os.path.join(os.path.dirname(__file__), "Elements.json")
-)
+el_chem_json_file = str(os.path.join(os.path.dirname(__file__), "Elements.json"))
 el_chem_json = open(el_chem_json_file, "r")
 chem_data = json.load(el_chem_json)
 el_chem_json.close()
 
-el_chrg_json_file = str(
-    os.path.join(os.path.dirname(__file__), "element_charge.json")
-)
+el_chrg_json_file = str(os.path.join(os.path.dirname(__file__), "element_charge.json"))
 el_chrg_json = open(el_chrg_json_file, "r")
 chrg_data = json.load(el_chrg_json)
 el_chrg_json.close()
@@ -262,18 +258,14 @@ def get_node_attributes(species, atom_features="atomic_number"):
     feature_sets = ("atomic_number", "basic", "cfid", "cgcnn")
 
     if atom_features not in feature_sets:
-        raise NotImplementedError(
-            f"atom features must be one of {feature_sets}"
-        )
+        raise NotImplementedError(f"atom features must be one of {feature_sets}")
 
     if atom_features == "cfid":
         return Specie(species).get_descrp_arr
     elif atom_features == "atomic_number":
         return [Specie(species).element_property("Z")]
     elif atom_features == "basic":
-        return [
-            Specie(species).element_property(prop) for prop in BASIC_FEATURES
-        ]
+        return [Specie(species).element_property(prop) for prop in BASIC_FEATURES]
     elif atom_features == "cgcnn":
         # load from json, key by atomic number
         key = str(Specie(species).element_property("Z"))
@@ -281,7 +273,11 @@ def get_node_attributes(species, atom_features="atomic_number"):
             # For alternative features use
             # get_digitized_feats_hot_encoded()
             i = json.load(f)
-        return i[key]
+        try:
+            return i[key]
+        except KeyError:
+            print(f"warning: could not load CGCNN features for {key}")
+            return None
 
 
 keys = [
@@ -377,9 +373,7 @@ def get_specie_data():
     return keys, chem_data, chrg_data
 
 
-def get_digitized_feats_hot_encoded(
-    feature_names=keys, filename="feats_encoded.json"
-):
+def get_digitized_feats_hot_encoded(feature_names=keys, filename="feats_encoded.json"):
     """Get OneHotEncoded features with digitized features."""
     from sklearn.preprocessing import OneHotEncoder
     import pandas as pd

--- a/jarvis/core/specie.py
+++ b/jarvis/core/specie.py
@@ -6,6 +6,7 @@ import numpy as np
 import functools
 from jarvis.core.utils import digitize_array
 from collections import defaultdict
+from collections.abc import Iterable
 
 el_chem_json_file = str(
     os.path.join(os.path.dirname(__file__), "Elements.json")
@@ -254,8 +255,6 @@ BASIC_FEATURES = [
     "first_ion_en",
     "elec_aff",
 ]
-
-from collections.abc import Iterable
 
 
 @functools.lru_cache(maxsize=None)

--- a/jarvis/core/specie.py
+++ b/jarvis/core/specie.py
@@ -255,16 +255,29 @@ BASIC_FEATURES = [
     "elec_aff",
 ]
 
+from collections.abc import Iterable
+
 
 @functools.lru_cache(maxsize=None)
 def get_node_attributes(species, atom_features="atomic_number"):
     """Get specific node features for an element."""
     feature_sets = ("atomic_number", "basic", "cfid", "cgcnn")
 
-    if atom_features not in feature_sets:
-        raise NotImplementedError(
-            f"atom features must be one of {feature_sets}"
-        )
+    if isinstance(atom_features, str):
+        if atom_features not in feature_sets:
+            raise NotImplementedError(
+                f"atom features must be one of {feature_sets}"
+            )
+    elif isinstance(atom_features, Iterable):
+        # allow custom list of features
+        for prop in atom_features:
+            if prop not in keys:
+                raise NotImplementedError(
+                    f"{prop} not supported in custom atom feature list"
+                )
+        return [
+            Specie(species).element_property(prop) for prop in atom_features
+        ]
 
     if atom_features == "cfid":
         return Specie(species).get_descrp_arr

--- a/jarvis/tests/testfiles/core/test_graph.py
+++ b/jarvis/tests/testfiles/core/test_graph.py
@@ -1,3 +1,4 @@
+from jarvis.core.atoms import Atoms
 from jarvis.core.graphs import StructureDataset, Graph
 from jarvis.db.figshare import data
 import os
@@ -65,15 +66,19 @@ def test_graph():
 
 def test_dataset():
     d = data("dft_2d")
-    x = []
-    y = []
-    z = []
-    for i in d[0:100]:
-        if i["formation_energy_peratom"] != "na":
-            x.append(i["atoms"])
-            y.append(i["formation_energy_peratom"])
-            z.append(i["jid"])
-    s = StructureDataset(x, y, ids=z)
+    d = d.iloc[:100]
+
+    graphs = []
+    for i, row in d.iterrows():
+        structure = Atoms.from_dict(row["atoms"])
+        g = Graph.atom_dgl_multigraph(
+            structure,
+            atom_features="atomic_number",
+            compute_line_graph=False,
+        )
+        graphs.append(g)
+
+    s = StructureDataset(d, graphs, "formation_energy_peratom")
     col = s.collate
 
 

--- a/jarvis/tests/testfiles/core/test_graph.py
+++ b/jarvis/tests/testfiles/core/test_graph.py
@@ -1,6 +1,7 @@
 from jarvis.core.atoms import Atoms
 from jarvis.core.graphs import StructureDataset, Graph
 from jarvis.db.figshare import data
+import pandas as pd
 import os
 
 test_pos = os.path.join(
@@ -66,7 +67,7 @@ def test_graph():
 
 def test_dataset():
     d = data("dft_2d")
-    d = d.iloc[:100]
+    d = pd.DataFrame(d[:100])
 
     graphs = []
     for i, row in d.iterrows():

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(base_dir, "README.rst")) as f:
 
 setup(
     name="jarvis-tools",
-    version="2021.4.19",
+    version="2021.4.21",
     long_description=long_d,
     install_requires=[
         "numpy>=1.18.5",


### PR DESCRIPTION
This PR tightens up the graph dataset caching so that for a given graph dataset and neighbor strategy, a single cache file is saved using the dgl binary format. The dataset accepts a pandas dataframe, a list of graphs, and a key for the modeling target corresponding to a column in the dataframe

Additionally, the dataset will optionally return a line graph (computed on demand when __getitem__ is called)