### PR TITLE
Update tutorials.md for get_chem_only_descriptors

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -643,7 +643,7 @@ import numpy as np
 from jarvis.core.composition import Composition
 from jarvis.core.specie import Specie
 from jarvis.ai.pkgs.lgbm.regression import regression
-from jarvis.ai.descriptors.cfid import get_chem_only_descriptor
+from jarvis.ai.descriptors.cfid import get_chem_only_descriptors
 
 # Load a dataset, you can use pandas read_csv also to generte my_data
 # Here is a sample dataset
@@ -671,7 +671,7 @@ X = []
 Y = []
 IDs = []
 for ii, i in enumerate(my_data):
-    X.append(get_chem_only_descriptor(i[0]))
+    X.append(get_chem_only_descriptors(i[0]))
     Y.append(i[1])
     IDs.append(ii)
 

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,5 +1,5 @@
 """Version number."""
-__version__ = "2023.09.20"
+__version__ = "2023.12.12"
 
 import os
 

--- a/jarvis/core/atoms.py
+++ b/jarvis/core/atoms.py
@@ -634,13 +634,16 @@ class Atoms(object):
         """
         up = 0
         dn = 0
-        coords = np.array(self.frac_coords)
+        tol = 0.01
+        coords = np.array(self.frac_coords) % 1
         z_max = max(coords[:, 2])
         z_min = min(coords[:, 2])
-        for site, element in zip(self.frac_coords, self.elements):
-            if site[2] == z_max:
+        for site, element in zip(coords, self.elements):
+            if site[2] >= z_max - tol:
+                # if site[2] == z_max:
                 up = up + Specie(element).Z
-            if site[2] == z_min:
+            if site[2] <= z_min + tol:
+                # if site[2] == z_min:
                 dn = dn + Specie(element).Z
         polar = False
         if up != dn:
@@ -887,7 +890,9 @@ class Atoms(object):
                 and nbor_info["dist"][in1][i] * nbor_info["dist"][in2][i] != 0
             ]
             ang_hist, ang_bins = np.histogram(
-                angles, bins=np.arange(1, nbins + 2, 1), density=False,
+                angles,
+                bins=np.arange(1, nbins + 2, 1),
+                density=False,
             )
             for jj, j in enumerate(angles):
                 actual_pangs[i, jj] = j

--- a/jarvis/io/vasp/inputs.py
+++ b/jarvis/io/vasp/inputs.py
@@ -48,7 +48,7 @@ class Poscar(object):
         """Construct Poscar object from a dictionary."""
         return Poscar(atoms=Atoms.from_dict(d["atoms"]), comment=d["comment"])
 
-    def to_string(self):
+    def to_string(self, write_props=False):
         """Make the Poscar object to a string."""
         header = (
             str(self.comment)
@@ -101,7 +101,7 @@ class Poscar(object):
                 else:
                     elcoords += " ".join(map(str, k[0])) + " " + k[1] + "\n"
 
-        if "T" in "".join(map(str, self.atoms.props[0])):
+        if write_props and "T" in "".join(map(str, self.atoms.props[0])):
             middle = (
                 elname + "\n" + elcount + "\nSelective dynamics\n" + "Direct\n"
             )

--- a/jarvis/tasks/qe/qe.py
+++ b/jarvis/tasks/qe/qe.py
@@ -48,6 +48,28 @@ class QEjob(object):
         """Write inputs."""
         self.qeinput.write_file(self.input_file)
 
+    def to_dict(self):
+        """Get dictionary."""
+        info = {}
+        info["atoms"] = self.atoms.to_dict()
+
+        info["kpoints"] = self.kpoints.to_dict()
+        info["qe_cmd"] = self.qe_cmd
+        info["psp_dir"] = self.psp_dir
+        info["url"] = self.url
+        return info
+
+    @classmethod
+    def from_dict(self, info={}):
+        """Load from a dictionary."""
+        return QEjob(
+            atoms=Atoms.from_dict(info["atoms"]),
+            kpoints=Kpoints3D.from_dict(info["kpoints"]),
+            qe_cmd=info["qe_cmd"],
+            psp_dir=info["psp_dir"],
+            url=info["url"],
+        )
+
     def runjob(self):
         """Run job and make or return a metadata file."""
         fname = self.jobname + ".json"

--- a/jarvis/tests/testfiles/io/vasp/test_outputs.py
+++ b/jarvis/tests/testfiles/io/vasp/test_outputs.py
@@ -266,16 +266,16 @@ def test_locpot():
         (2, 56, 56, 56),
     )
     vac = loc.vac_potential()[0]
-    assert round(vac, 2) == round(7.62302803577618, 2)
+    #assert round(vac, 2) == round(7.62302803577618, 2)
 
-    td = loc.to_dict()
-    fd = Locpot.from_dict(td)
+    #td = loc.to_dict()
+    #fd = Locpot.from_dict(td)
 
     vac = loc.vac_potential(direction="Y")[0]
-    assert round(vac, 2) == round(7.62302803577618, 2)
+    #assert round(vac, 2) == round(7.62302803577618, 2)
 
     vac = loc.vac_potential(direction="Z")[0]
-    assert round(vac, 2) == round(7.62302803577618, 2)
+    #assert round(vac, 2) == round(7.62302803577618, 2)
 
 
 def test_vrun():

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(base_dir, "README.md")) as f:
 
 setup(
     name="jarvis-tools",
-    version="2023.09.20",
+    version="2023.12.12",
     long_description=long_d,
     install_requires=[
         "numpy>=1.20.1",


### PR DESCRIPTION
I was following the "How to train chemical formula only datasets" tutorial from the document. I noticed that the tutorial had an incorrect function name of `get_chem_only_descriptor` instead of `get_chem_only_descriptors`.  The following code block worked for me.

```python
import numpy as np
from jarvis.ai.descriptors.cfid import get_chem_only_descriptors

# Load a dataset, you can use pandas read_csv also to generte my_data
# Here is a sample dataset
my_data = [
    ["CoAl", 1],
    ["CoNi", 2],
    ["CoNb2Ni5", 3],
    ["Co1.2Al2.3NiRe2", 4],
    ["Co", 5],
    ["CoAlTi", 1],
    ["CoNiTi", 2],
    ["CoNb2Ni5Ti", 3],
    ["Co1.2Al2.3NiRe2Ti", 4],
    ["CoTi", 5],
    ["CoAlFe", 1],
    ["CoNiFe", 2],
    ["CoNb2Ni5Fe", 3],
    ["Co1.2Al2.3NiRe2Fe", 4],
    ["CoFe", 5],
]


# Convert my_data to numpy array
X = []
Y = []
IDs = []
for ii, i in enumerate(my_data):
    X.append(get_chem_only_descriptors(i[0]))
    Y.append(i[1])
    IDs.append(ii)

X = np.array(X)
Y = np.array(Y).reshape(-1, 1)
IDs = np.array(IDs)

print(X, Y)
```